### PR TITLE
Refine progress bar styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,6 +175,8 @@
             </div>
         </div>
 
+        <div id="progress-container" class="progress-container"></div>
+
         <div id="completion-banner">
             <h4><i class="fas fa-stamp"></i> ¡Expediente completo! Listo para sellar.</h4>
             <button id="print-dashboard-btn" class="boton-panel-pdf"><i class="fas fa-share-alt"></i> Compartir / Guardar Panel (PDF)</button>

--- a/script.js
+++ b/script.js
@@ -129,6 +129,7 @@ function initializeApp(initialChars, initialPacks) {
             'print-dashboard-btn',
             'detective-guide-section', 'guide-header-tab',
             'completion-banner',
+            'progress-container',
             'toast-notification', 'toast-message',
             'host-name-input',
             'event-date-input',
@@ -726,6 +727,25 @@ function initializeApp(initialChars, initialPacks) {
             return (Math.random() * (maxAngle * 2)) - maxAngle;
         }
 
+        // Mostrar progreso de asignación
+        function updateProgressIndicator() {
+            const container = document.getElementById('progress-container');
+            if (!container) return;
+
+            const total = currentCharacters.length;
+            const assigned = assignedPlayerMap.size;
+            const percentage = total > 0 ? (assigned / total) * 100 : 0;
+
+            const progressHTML = `
+                <div class="assignment-progress">
+                    <div class="progress-bar" style="width: ${percentage}%"></div>
+                    <span class="progress-text">${assigned} de ${total} asignados</span>
+                </div>
+            `;
+
+            container.innerHTML = progressHTML;
+        }
+
         function updateAssignmentDashboard() {
             if(!domElements['assignment-table-body']){return;}domElements['assignment-table-body'].innerHTML='';if(currentCharacters.length===0)return;
             currentCharacters.forEach(char=>{
@@ -756,6 +776,8 @@ function initializeApp(initialChars, initialPacks) {
         }
 
         function checkCompletionState() {
+            updateProgressIndicator();
+
             const banner = domElements['completion-banner'];
             const dashboard = domElements['assignment-dashboard-section'];
             if (!banner) return;

--- a/style.css
+++ b/style.css
@@ -890,6 +890,65 @@ button .fas, button .fab { margin-right: 8px; }
 
 
 /* ============================================= */
+/* Barra de Progreso de Asignación               */
+/* ============================================= */
+#progress-container {
+    position: fixed;
+    bottom: 30px;
+    right: 30px;
+    width: 260px;
+    padding: 8px;
+    background-color: var(--color-content-bg);
+    border: 1px solid var(--color-gold-dark);
+    border-radius: var(--border-radius-medium);
+    box-shadow: var(--box-shadow-medium);
+    z-index: 1000;
+}
+
+.assignment-progress {
+    position: relative;
+    height: 24px;
+    background-color: var(--color-content-bg);
+    border: 1px solid var(--color-gold-dark);
+    border-radius: var(--border-radius-soft);
+    overflow: hidden;
+}
+
+.progress-bar {
+    height: 100%;
+    background-color: var(--color-gold-medium);
+    transition: width 0.4s ease;
+}
+
+.progress-text {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    color: var(--color-text-dark);
+}
+
+:root.dark-mode #progress-container {
+    background-color: var(--color-cream-artdeco);
+    border-color: var(--color-gold-medium);
+    box-shadow: 0 5px 15px rgba(0,0,0,0.25);
+}
+
+:root.dark-mode .assignment-progress {
+    background-color: var(--color-cream-artdeco);
+    border-color: var(--color-gold-medium);
+}
+
+:root.dark-mode .progress-bar {
+    background-color: var(--color-gold-dark);
+}
+
+/* ============================================= */
 /* Estilos Banner de Finalización                */
 /* ============================================= */
 #completion-banner {


### PR DESCRIPTION
## Summary
- style progress indicator as a floating panel
- use golden hues from the theme instead of green

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e163ed73483258ff02bc227ba42ce