### PR TITLE
Add dark mode styles for case details

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,10 @@
                 <span class="toggle-text">Modo Noche</span>
             </button>
         </div>
+        <div id="assignment-progress" style="display:none;">
+            <div class="progress-text">0 / 0</div>
+            <div class="progress-bar-bg"><div class="progress-bar-fill"></div></div>
+        </div>
 
         <div class="folder-tab" id="guide-header-tab">
           📂 <span><strong>Apertura del Expediente:</strong></span>

--- a/script.js
+++ b/script.js
@@ -133,7 +133,8 @@ function initializeApp(initialChars, initialPacks) {
             'has-honoree-checkbox', 'honorees-container', 'add-honoree-btn',
             'decrement-player-count', 'increment-player-count',
             'initial-report-target',
-            'intro-line-1-heading'
+            'intro-line-1-heading',
+            'assignment-progress'
         ];
         const domElements = {};
         let allElementsFound = true;
@@ -725,9 +726,11 @@ function initializeApp(initialChars, initialPacks) {
         function checkCompletionState() {
             const banner = domElements['completion-banner'];
             if (!banner) return;
-    
+
             const totalCharacters = currentCharacters.length;
             const assignedCharacters = assignedPlayerMap.size;
+
+            updateAssignmentProgress(totalCharacters, assignedCharacters);
     
             if (totalCharacters > 0 && assignedCharacters === totalCharacters) {
                 const alreadyVisible = banner.classList.contains('visible');
@@ -741,6 +744,24 @@ function initializeApp(initialChars, initialPacks) {
             } else {
                 banner.classList.remove('visible');
             }
+        }
+
+        function updateAssignmentProgress(totalCharacters, assignedCharacters) {
+            const progressEl = domElements['assignment-progress'];
+            if (!progressEl) return;
+
+            const textEl = progressEl.querySelector('.progress-text');
+            const fillEl = progressEl.querySelector('.progress-bar-fill');
+
+            if (textEl) {
+                textEl.textContent = `${assignedCharacters} / ${totalCharacters}`;
+            }
+            if (fillEl) {
+                const percent = totalCharacters > 0 ? (assignedCharacters / totalCharacters) * 100 : 0;
+                fillEl.style.width = `${percent}%`;
+            }
+
+            progressEl.style.display = totalCharacters > 0 ? 'block' : 'none';
         }
 
         function populateAndShowCompletionBanner() {
@@ -1033,6 +1054,10 @@ function initializeApp(initialChars, initialPacks) {
                 domElements['setup-section'].scrollIntoView({ behavior: 'smooth', block: 'start' });
             }, 100);
 
+            if(domElements['assignment-progress']){
+                domElements['assignment-progress'].style.display = 'none';
+            }
+
             showToastNotification('Has vuelto a la configuración. Los datos se conservan.', 'info');
         }
 
@@ -1130,6 +1155,9 @@ function initializeApp(initialChars, initialPacks) {
             domElements['setup-section'].style.display = 'none';
             domElements['main-content-area'].classList.remove('hidden-section');
             domElements['main-content-area'].classList.add('visible-section');
+            if(domElements['assignment-progress']){
+                domElements['assignment-progress'].style.display = 'block';
+            }
             if (domElements['action-buttons-section']) {
                  domElements['action-buttons-section'].scrollIntoView({ behavior: 'smooth', block: 'start' });
             } else if (domElements['guide-header-tab']) {

--- a/style.css
+++ b/style.css
@@ -1922,3 +1922,77 @@ button .fas, button .fab { margin-right: 8px; }
 }
 
 /* 👉👉 FIN BLOQUE 4 👈👈 */
+
+/* ============================================= */
+/* === MEJORAS MODO NOCHE PARA EL INFORME FINAL === */
+/* ============================================= */
+
+/* Cambia el fondo blanco del papel por un tono oscuro temático */
+:root.dark-mode .case-details {
+    background: #25231e; /* Un tono de papel antiguo oscuro */
+    border-color: var(--color-gold-dark);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.4), inset 0 0 15px rgba(0,0,0,0.3);
+}
+
+/* Asegura que el texto de las etiquetas sea claro y legible */
+:root.dark-mode .case-details .detail-label {
+    color: var(--color-text-medium);
+}
+
+/* Asegura que los valores (nombres, fechas, etc.) también sean claros */
+:root.dark-mode .case-details .detail-value {
+    color: var(--color-text-dark);
+}
+
+/* ============================================= */
+/* === PROGRESS BAR DE ASIGNACION ============= */
+/* ============================================= */
+#assignment-progress {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background: rgba(0,0,0,0.65);
+    border-bottom: 1px solid var(--color-gold-medium);
+    border-left: none;
+    border-right: none;
+    border-top: none;
+    border-radius: 0 0 5px 5px;
+    padding: 6px 12px;
+    z-index: 999;
+    font-family: var(--font-special);
+    color: var(--color-gold-light);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+}
+
+#assignment-progress .progress-text {
+    text-align: center;
+    font-size: 0.9em;
+}
+
+#assignment-progress .progress-bar-bg {
+    width: 80%;
+    height: 8px;
+    background: var(--color-black-artdeco);
+    border-radius: 4px;
+    overflow: hidden;
+    margin-top: 5px;
+}
+
+#assignment-progress .progress-bar-fill {
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(to right, var(--color-gold-dark), var(--color-gold-light));
+    transition: width 0.3s ease;
+}
+
+:root.dark-mode #assignment-progress {
+    background: rgba(20,20,20,0.7);
+    border-color: var(--color-gold-dark);
+}
+:root.dark-mode #assignment-progress .progress-bar-bg {
+    background: #555;
+}


### PR DESCRIPTION
## Summary
- style the case details panel when dark mode is enabled
- add floating progress bar that shows players assigned
- keep progress bar pinned to the top of the page while scrolling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ecab2862083258f4e53a7348e6c58