### PR TITLE
Fix mobile text overflow in typewriter message

### DIFF
--- a/script.js
+++ b/script.js
@@ -761,13 +761,22 @@ function initializeApp(initialChars, initialPacks) {
                 fillEl.style.width = `${percent}%`;
             }
 
-            progressEl.style.display = totalCharacters > 0 ? 'block' : 'none';
+            if (assignedCharacters === totalCharacters && totalCharacters > 0) {
+                progressEl.style.display = 'none';
+            } else {
+                progressEl.style.display = totalCharacters > 0 ? 'block' : 'none';
+            }
         }
 
-        function populateAndShowCompletionBanner() {
-            const banner = domElements['completion-banner'];
-            if (!banner) return;
-    
+       function populateAndShowCompletionBanner() {
+           const banner = domElements['completion-banner'];
+           if (!banner) return;
+
+            const progressEl = domElements['assignment-progress'];
+            if (progressEl) {
+                progressEl.style.display = 'none';
+            }
+
             // Poblar detalles del informe
             document.getElementById('completion-host-name').textContent = hostName || 'No especificado';
             document.getElementById('completion-event-date').textContent = getFormattedEventDate(eventDateValue) || 'Fecha no especificada';

--- a/style.css
+++ b/style.css
@@ -1894,8 +1894,10 @@ button .fas, button .fab { margin-right: 8px; }
     #completion-message {
         /* Reduce el tamaño del texto para que quepa en pantallas pequeñas */
         font-size: 0.9em;
-        /* Forzamos que la animación de escritura se ajuste */
-        animation-duration: 2.5s;
+        /* Ajustes para evitar que el texto se corte */
+        animation: none;
+        white-space: normal;
+        overflow: visible;
     }
 }
 


### PR DESCRIPTION
## Summary
- adjust `#completion-message` style for small screens to avoid overflow

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684edd8128b08325971c4a9a65d907c8