### PR TITLE
Improve date field flow

### DIFF
--- a/script.js
+++ b/script.js
@@ -1485,6 +1485,12 @@ function setupProgressiveFlow() {
   const namesContainer = document.getElementById('player-names-grid-container');
 
   if (dateInput) {
+    dateInput.addEventListener('change', () => {
+      if (dateInput.value) {
+        showBloque(3);
+        if (hostInput) hostInput.focus();
+      }
+    });
     dateInput.addEventListener('blur', () => {
       if (dateInput.value) showBloque(3);
     });


### PR DESCRIPTION
## Summary
- show the next setup block when the date is selected
- move focus to the host name input automatically

## Testing
- `npm test` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_68503a5790788325b1d9b042f6be6a1e