### PR TITLE
Remove event date input writes

### DIFF
--- a/script.js
+++ b/script.js
@@ -287,7 +287,6 @@ function initializeApp(initialChars, initialPacks) {
             assignedPlayerMap.clear();
 
             if(domElements['host-name-input']) domElements['host-name-input'].value = hostName; else hostName = "";
-            if(domElements['event-date-input']) domElements['event-date-input'].value = eventDateValue; else eventDateValue = "";
 
             if(domElements['has-honoree-checkbox']) {
                 domElements['has-honoree-checkbox'].checked = honoreeNames.length > 0;
@@ -1049,9 +1048,6 @@ function initializeApp(initialChars, initialPacks) {
                 // Restore previously entered host and date values
                 if (domElements['host-name-input']) {
                     domElements['host-name-input'].value = hostName;
-                }
-                if (domElements['event-date-input']) {
-                    domElements['event-date-input'].value = eventDateValue;
                 }
 
                 const existingNames = Array.from(domElements['player-names-grid-container']?.querySelectorAll('input.player-name-box'))


### PR DESCRIPTION
## Summary
- stop writing back the stored event date to the date input
- keep only reads when updating eventDateValue

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850567f350c8325a1228fd6018bd3b2