### PR TITLE
Focus host input after date selection on desktop

### DIFF
--- a/script.js
+++ b/script.js
@@ -1481,9 +1481,15 @@ function setupProgressiveFlow() {
   const namesContainer = document.getElementById('player-names-grid-container');
 
   if (dateInput) {
-    dateInput.addEventListener('blur', () => {
-      if (dateInput.value) showBloque(3);
-    });
+    const handleDateEvent = evt => {
+      if (!dateInput.value) return;
+      showBloque(3);
+      if (evt.type === 'change' && isDesktop() && hostInput) {
+        hostInput.focus();
+      }
+    };
+    dateInput.addEventListener('change', handleDateEvent);
+    dateInput.addEventListener('blur', handleDateEvent);
   }
   if (hostInput) {
     hostInput.addEventListener('blur', () => {


### PR DESCRIPTION
## Summary
- when a date is chosen show the next block
- automatically move focus to the host name field on desktop devices only

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68511cd629208325b23e22e21b168d93