### PR TITLE
Focus host input only on desktop

### DIFF
--- a/script.js
+++ b/script.js
@@ -1481,8 +1481,14 @@ function setupProgressiveFlow() {
   const namesContainer = document.getElementById('player-names-grid-container');
 
   if (dateInput) {
+    dateInput.addEventListener('change', () => {
+      if (!isDesktop() || !dateInput.value) return;
+      showBloque(3);
+      if (hostInput) hostInput.focus();
+    });
     dateInput.addEventListener('blur', () => {
-      if (dateInput.value) showBloque(3);
+      if (isDesktop() || !dateInput.value) return;
+      showBloque(3);
     });
   }
   if (hostInput) {


### PR DESCRIPTION
## Summary
- update date selection handler so progressive flow triggers only on desktop `change` events
- keep mobile behavior unchanged by using `blur` listener

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68511cd629208325b23e22e21b168d93