### PR TITLE
Update detective guide icon layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,19 +148,34 @@
                     en cada ficha para mandar los <strong>detalles del sospechoso</strong> directamente al jugador asignado de forma <strong>confidencial</strong>. Cuando termines el reparto, pulsa "<strong>Guardar asignación</strong>" para conservar el resumen.</span>
                 </li>
             </ol>
-            <div class="special-considerations">
-                <h5><i class="fas fa-lightbulb"></i> <strong>Significado de los iconos:</strong></h5>
-                <ul>
-                    <li>
-                        <span style="font-size: 1.3em;" title="Ideal para el/la homenajeado/a">🌟</span> <strong>Para el/la Homenajeado/a:</strong> sospechosos que tienen un <strong>rol más principal</strong>.
-                    </li>
-                    <li>
-                        <span style="font-size: 1.3em;" title="Apto para menores (+12 aprox, con supervisión)">🧸</span> <strong>Apto para Menores de edad:</strong> fáciles de entender y <strong>sin temática +18</strong>.
-                    </li>
-                    <li>
-                        <span style="font-size: 1.3em;" title="Ideal para jugadores mayores o novatos">👵🏻</span> <strong>Jugadores Mayores:</strong> fáciles de <strong>entender y representar</strong>.
-                    </li>
-                </ul>
+            <!-- Bloque Significado de los Iconos -->
+            <div class="iconos-guia">
+              <h3>💡 Significado de los iconos:</h3>
+              <div class="iconos-list">
+                <div class="icono-box">
+                  <span class="emoji">🌟</span>
+                  <div class="icono-texto">
+                    <strong>Para el/la Homenajeado/a</strong>
+                    <p>Sospechosos que tienen un <em>rol más principal</em>.</p>
+                  </div>
+                </div>
+
+                <div class="icono-box">
+                  <span class="emoji">🧸</span>
+                  <div class="icono-texto">
+                    <strong>Apto para Menores de edad</strong>
+                    <p>Fáciles de entender y <em>sin temática +18</em>.</p>
+                  </div>
+                </div>
+
+                <div class="icono-box">
+                  <span class="emoji">👵🏻</span>
+                  <div class="icono-texto">
+                    <strong>Jugadores Mayores</strong>
+                    <p>Fáciles de <em>entender y representar</em>.</p>
+                  </div>
+                </div>
+              </div>
             </div>
         </div>
 

--- a/style.css
+++ b/style.css
@@ -785,11 +785,64 @@ button .fas, button .fab { margin-right: 8px; }
 #detective-guide-section h4 .fas { margin-right: 10px; font-size: 0.9em; }
 
 #detective-guide-section ol { list-style-type: none; padding-left: 0; font-size: 1.05em; counter-reset: guide-counter; }
-#detective-guide-section ol li { position: relative; margin-bottom: 12px; padding-left: 55px; line-height: 1.6; min-height: 40px; }
+#detective-guide-section ol li { position: relative; margin-bottom: 20px; padding-left: 55px; line-height: 1.6; min-height: 40px; }
 #detective-guide-section ol li::before { counter-increment: guide-counter; content: counter(guide-counter) "."; position: absolute; left: 0px; top: -5px; font-family: var(--font-special), serif; font-weight: bold; font-size: 3em; line-height: 1; color: var(--color-gold-dark); width: 45px; text-align: right; padding-right: 10px; }
 #detective-guide-section strong { font-weight: 600; color: var(--color-text-dark); }
+.iconos-guia {
+    background: #fdf5e6;
+    border: 2px solid #d3b574;
+    border-radius: 8px;
+    padding: 20px;
+    margin-top: 30px;
+    font-family: 'Special Elite', serif;
+    color: #3b2e1a;
+    max-width: 600px;
+    margin-inline: auto;
+    box-shadow: 0 0 6px rgba(0,0,0,0.1);
+}
+.iconos-guia h3 {
+    margin-bottom: 18px;
+    font-size: 18px;
+    color: #4a321a;
+    border-bottom: 1px dashed #c0a062;
+    padding-bottom: 6px;
+}
+.iconos-list {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+.icono-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    background: var(--color-gold-pale);
+    border: 1px solid var(--color-gold-medium);
+    border-radius: 6px;
+    padding: 14px 10px;
+    gap: 6px;
+}
+.icono-texto {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+.icono-box .emoji {
+    font-size: 28px;
+}
+.icono-box strong {
+    color: #3d2b1f;
+    font-weight: bold;
+    font-size: 15px;
+}
+.icono-box em {
+    color: #6b4a2f;
+    font-style: normal;
+}
 .suspect-profiles { margin-top: 10px; margin-bottom: 10px; display: flex; flex-wrap: wrap; justify-content: center; gap: 12px; padding-left: 0; }
-.suspect-profile-card { max-width: 300px; width: 100%; text-align: center; font-family: var(--font-special), monospace; font-weight: bold; font-size: 0.9em; background: #fff5d0; border: 2px solid #444; border-radius: 0; color: #2a2a2a; padding: 6px 12px; box-shadow: 1px 1px 2px rgba(0,0,0,0.3); transform: rotate(-2deg); display: flex; flex-direction: column; align-items: center; letter-spacing: 0.5px; }
+.suspect-profile-card { max-width: 300px; width: 100%; text-align: center; font-family: var(--font-special), monospace; font-weight: bold; font-size: 0.9em; background: #fff5d0; border: 2px solid #444; border-radius: 0; color: #2a2a2a; padding: 6px 12px; box-shadow: 1px 1px 2px rgba(0,0,0,0.3); display: flex; flex-direction: column; align-items: center; letter-spacing: 0.5px; }
 :root.dark-mode #detective-guide-section .suspect-profile-card { background: #38352e; border-color: var(--color-gold-medium); color: var(--color-gold-light); }
 .suspect-profile-card .profile-title { font-weight: 600; text-transform: uppercase; }
 .suspect-profile-card .profile-desc { font-size: 0.8em; text-transform: none; }
@@ -799,9 +852,25 @@ button .fas, button .fab { margin-right: 8px; }
 :root.dark-mode #detective-guide-section ol li::before { color: var(--color-gold-medium); }
 :root.dark-mode #detective-guide-section strong { color: var(--color-text-dark); }
 :root.dark-mode #detective-guide-section .extroversion-pill { background: #38352e; color: var(--color-gold-light); border-color: var(--color-gold-medium); }
-:root.dark-mode #detective-guide-section .special-considerations { border-top-color: var(--color-gold-dark); }
-:root.dark-mode #detective-guide-section .special-considerations h5 { color: var(--color-gold-light); }
-:root.dark-mode #detective-guide-section .special-considerations h5 .fas { color: var(--color-gold-medium); }
+:root.dark-mode #detective-guide-section .iconos-guia {
+    background: #292520;
+    border-color: var(--color-gold-dark);
+    color: var(--color-gold-light);
+}
+:root.dark-mode #detective-guide-section .iconos-guia h3 {
+    color: var(--color-gold-light);
+    border-bottom-color: var(--color-gold-medium);
+}
+:root.dark-mode #detective-guide-section .icono-box strong {
+    color: var(--color-gold-light);
+}
+:root.dark-mode #detective-guide-section .icono-box em {
+    color: var(--color-gold-medium);
+}
+:root.dark-mode #detective-guide-section .icono-box {
+    background: #1c1c1c;
+    border-color: var(--color-gold-dark);
+}
 
 /* ============================================= */
 /* Estilos Columnas de Personajes                */
@@ -1010,7 +1079,7 @@ button .fas, button .fab { margin-right: 8px; }
 /* Nivel de interpretación (píldoras) y iconos */
 .extroversion-level-wrapper { display: flex; align-items: center; justify-content: space-between; margin-bottom: 15px; }
 .extroversion-level-container { display: inline-flex; }
-.extroversion-pill { font-family: var(--font-special), monospace; font-weight: bold; font-size: 0.9em; border-radius: 0px;  background: #fff5d0;  border: 2px solid #444;  color: #2a2a2a;  padding: 6px 12px; box-shadow: 1px 1px 2px rgba(0,0,0,0.3); transform: rotate(-2deg);  display: inline-flex; align-items: center; text-transform: uppercase; letter-spacing: 0.5px; }
+.extroversion-pill { font-family: var(--font-special), monospace; font-weight: bold; font-size: 0.9em; border-radius: 0px;  background: #fff5d0;  border: 2px solid #444;  color: #2a2a2a;  padding: 6px 12px; box-shadow: 1px 1px 2px rgba(0,0,0,0.3); transform: rotate(-2deg); display: inline-flex; align-items: center; text-transform: uppercase; letter-spacing: 0.5px; }
 .extroversion-pill .fas { margin-right: 6px; font-size: 0.85em; }
 .card-icons-indicators { display: flex; align-items: center; gap: 10px; margin-left: auto;  }
 
@@ -1851,6 +1920,11 @@ button .fas, button .fab { margin-right: 8px; }
 
 @media (min-width: 580px) { .character-gallery-grid { grid-template-columns: repeat(2, 1fr); gap: 15px; } }
 @media (min-width: 768px) { .character-gallery-grid { grid-template-columns: repeat(3, 1fr); gap: 20px; } }
+@media (min-width: 768px) {
+    .iconos-guia { max-width: 900px; }
+    .iconos-list { flex-direction: row; }
+    .icono-box { flex: 1; }
+}
 @media (min-width: 1024px) { .character-gallery-grid { grid-template-columns: repeat(4, 1fr); gap: 25px; } }
 
 @media (max-width: 767px) {
@@ -1902,6 +1976,16 @@ button .fas, button .fab { margin-right: 8px; }
     #detective-guide-section .suspect-profile-card {
         width: 100%;
         font-size: 0.8em;
+    }
+
+    #detective-guide-section .icono-box {
+        flex-direction: row;
+        align-items: flex-start;
+        text-align: left;
+        gap: 12px;
+    }
+    #detective-guide-section .icono-texto {
+        align-items: flex-start;
     }
 
     #completion-message {


### PR DESCRIPTION
## Summary
- restructure icon list markup with `.iconos-list` wrapper
- style `.icono-box` as individual cards and arrange horizontally on larger screens
- expand dark-mode styles for the new layout
- straighten profile cards and extroversion labels
- restore rotated appearance for extroversion pills in the gallery
- refine mobile layout so emoji icons appear left with text stacked beside them

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6851982cc2688325bf5d6a0697861889